### PR TITLE
Dyer Cactus fix

### DIFF
--- a/scripts/Additions.zs
+++ b/scripts/Additions.zs
@@ -24,6 +24,12 @@ craftingTable.addShapeless("iron_to_ore", <item:minecraft:iron_ore>, [<item:exni
 
 craftingTable.addShapeless("gold_to_ore", <item:minecraft:gold_ore>, [<item:exnihilosequentia:chunk_gold>, <item:minecraft:stone>]);
 
+
+
+// fixing dyer by removing cactus paste and going straight to midori blocks which is the only use of paste anyway
+craftingTable.addShaped("cactus_to_midori", <item:quark:midori_block> * 4, [<item:minecraft:cactus>, <item:minecraft:cactus>, <null>, <item:minecraft:cactus>, <item:minecraft:cactus>]);
+
+
 //Tags
 
 <tag:items:forge:storage_blocks/compressed_dirt>.add(<item:excompressum:compressed_dirt>);

--- a/scripts/Additions.zs
+++ b/scripts/Additions.zs
@@ -26,12 +26,9 @@ craftingTable.addShapeless("gold_to_ore", <item:minecraft:gold_ore>, [<item:exni
 
 
 
-// fixing dyer by removing cactus paste and going straight to midori blocks which is the only use of paste anyway
-craftingTable.addShaped("cactus_to_midori", <item:quark:midori_block> * 4, [
-	[<item:minecraft:cactus>, <item:minecraft:cactus>],
-	[<item:minecraft:cactus>, <item:minecraft:cactus>]
-]);
-furnace.addRecipe("cactus_to_green", <item:minecraft:green_dye>, <item:minecraft:cactus>, 1.0, 0);
+// fixing cactus for minecolonies dyer
+craftingTable.addShapeless("cactus_to_paste", <item:quark:cactus_paste>, [<item:pamhc2foodcore:grinderitem>, <item:minecraft:cactus>]);
+furnace.addRecipe("cactus_to_green", <item:minecraft:green_dye>, <item:minecraft:cactus>, 1.0, 200);
 
 
 //Tags

--- a/scripts/Additions.zs
+++ b/scripts/Additions.zs
@@ -27,7 +27,11 @@ craftingTable.addShapeless("gold_to_ore", <item:minecraft:gold_ore>, [<item:exni
 
 
 // fixing dyer by removing cactus paste and going straight to midori blocks which is the only use of paste anyway
-craftingTable.addShaped("cactus_to_midori", <item:quark:midori_block> * 4, [<item:minecraft:cactus>, <item:minecraft:cactus>, <null>, <item:minecraft:cactus>, <item:minecraft:cactus>]);
+craftingTable.addShaped("cactus_to_midori", <item:quark:midori_block> * 4, [
+	[<item:minecraft:cactus>, <item:minecraft:cactus>],
+	[<item:minecraft:cactus>, <item:minecraft:cactus>]
+]);
+furnace.addRecipe("cactus_to_green", <item:minecraft:green_dye>, <item:minecraft:cactus>, 1.0, 0);
 
 
 //Tags

--- a/scripts/Removed.zs
+++ b/scripts/Removed.zs
@@ -194,3 +194,6 @@ craftingTable.removeRecipe(<item:mob_grinding_utils:entity_spawner>);
 
 craftingTable.removeRecipe(<item:darkutils:blank_plate>);
 
+// Quark
+
+furnace.removeRecipe(<item:quark:cactus_paste>);

--- a/scripts/Removed.zs
+++ b/scripts/Removed.zs
@@ -196,4 +196,5 @@ craftingTable.removeRecipe(<item:darkutils:blank_plate>);
 
 // Quark
 
+// fixing dyer by removing cactus paste and going straight to midori blocks which is the only use of paste anyway
 furnace.removeRecipe(<item:quark:cactus_paste>);

--- a/scripts/Removed.zs
+++ b/scripts/Removed.zs
@@ -196,5 +196,5 @@ craftingTable.removeRecipe(<item:darkutils:blank_plate>);
 
 // Quark
 
-// fixing dyer by removing cactus paste and going straight to midori blocks which is the only use of paste anyway
+// fixing cactus for minecolonies dyer
 furnace.removeRecipe(<item:quark:cactus_paste>);


### PR DESCRIPTION
This is a potential fix for the Dyer. I have removed the Cactus to Cactus Paste furnace recipe and added a shapeless Cactus + Pam's Grinder recipe to replace it.

This should allow the dyer to make Green Dye with the vanilla recipe he starts with... Vanilla recipe to cook Cactus needed to be re added for this which is included.

I thought this would be a better fix than modifying the Minecolonies recipe that the Dyer's Hut starts with, but it's up to you.

I tested this in single player and it seemed fine.

A breakdown of what I did
1. Removed Cactus Paste furnace recipe
2. Added shapeless crafting recipe with Cactus and Pam's Grinder to make Cactus Paste
3. Re-Added vanilla furnace recipe to cook Cactus in to Green Dye to make the Dyer from MineColonies happy